### PR TITLE
Dinobug archeliondust

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To run the project locally, run `npm start`.
 
 ## Eternal-Twin
 
-If you are interested in the original game, you can found a recreation of it using this project over at Eternal-Twin: [Eternal Dino-RPG](https://dinorpg.eternaltwin.org/).
+If you are interested in the original game, you can found a recreation of it using this project over at Eternal-Twin: [DinoRPG](https://dinorpg.eternaltwin.org/).
 
 ## License
 

--- a/src/fight/Fighter.js
+++ b/src/fight/Fighter.js
@@ -666,7 +666,9 @@ export class Fighter extends Phys {
 				if (this._focus == null && this._lockTimer <= 0) {
 					this.updateWait(timer);
 				}
-				this.checkBounds(timer);
+				if (!this._tweenMove) {
+					this.checkBounds(timer);
+				}
 				break;
 			case Fighter.Mode.Anim:
 				if (this._animator.hasAnimEnded) {


### PR DESCRIPTION
## Problème

Lors d'une entrée de type Run (coq, arcadu, barche, becplu, worm, wteamc),
la fumée générée par fxAttach() apparaissait au mauvais endroit sur la scène
quand l'animation tournait en mode accéléré (settings.speed > 1).

## Cause

Dans Fighter.update(), checkBounds() s'exécute après updatePos() mais avant
_animator.update(). À vitesse accélérée (tmod > 1), sa correction sur _x
(dx * 0.3 * tmod) est suffisamment grande pour faire sauter _x depuis une
position hors-écran (~540) jusqu'au milieu de la scène (~319). Comme _root.x
n'est pas mis à jour par checkBounds(), il y a alors un déphasage entre _x
(utilisé par fxAttach) et _root.x (utilisé par fxAttachScene). Les effets
fxAttach apparaissent à la position corrigée par checkBounds plutôt qu'à la
position visuelle réelle du fighter.

## Fix

Quand le Fighter est en mode Waiting, on ne lance pas checkBounds() lorsqu'un _tweenMove est actif. Le tween gère
déjà le déplacement vers une destination toujours dans les limites de la scène,
checkBounds() n'a donc aucune correction légitime à apporter pendant cette
phase — et son exécution interférait avec la position logique du fighter.